### PR TITLE
General security - Accoundwechsel über URL

### DIFF
--- a/src/main/java/stellarbytestudios/socialboard/controller/UserPageConntroller.java
+++ b/src/main/java/stellarbytestudios/socialboard/controller/UserPageConntroller.java
@@ -43,7 +43,7 @@ public class UserPageConntroller {
         userService.saveNewDrop(username, dropcontent);
 
         // Redirecten
-        readds.addAttribute("username", username);
+        readds.addFlashAttribute("username", username);
         return "redirect:" + USERCONTROLLER + USERFEED;
     }
 }

--- a/src/main/java/stellarbytestudios/socialboard/controller/UserPageConntroller.java
+++ b/src/main/java/stellarbytestudios/socialboard/controller/UserPageConntroller.java
@@ -36,8 +36,8 @@ public class UserPageConntroller {
         return "userpage";
     }
 
-    @PostMapping(NEWDROP + "/{username}")
-    public String userDropsSomething(@PathVariable String username, String dropcontent, RedirectAttributes readds){
+    @PostMapping(NEWDROP)
+    public String userDropsSomething(String username, String dropcontent, RedirectAttributes readds){
 
         // Neuen Drop abspeichern
         userService.saveNewDrop(username, dropcontent);

--- a/src/main/resources/templates/userpage.html
+++ b/src/main/resources/templates/userpage.html
@@ -18,11 +18,12 @@
                 Was willst du loswerden und mit der Welt teilen?
             </p>
             Erstelle hier einen neuen Eintrag:
-            <form method="post" th:action="@{/user/neuerDrop/} + ${username}">
+            <form method="post" th:action="@{/user/neuerDrop}">
                 <table class="table">
                     <tr>
                         <textarea class="form-control" rows="3" name="dropcontent" placeholder="Teile dich mit"></textarea>
                     </tr>
+                    <input type="hidden" name="username" th:value="*{username}">
                     <br>
                     <tr>
                         <button type="submit" class=" btn btn-primary">Dropen</button>


### PR DESCRIPTION
# Sicherheitslücke Accoundwechsel via URL

Man konnte zuvor sich als einen anderen Accound noch ausgeben, wenn man das in die URL geschrieben hat. Diese Lücke war offen, nachdem man einen Drop abgeschick hat.
Zusätzlich hab ich auch noch rausgenommen dass, wenn man einen Drop abschickt, der Autor nicht über die URL übertragen wird sondern ebenfalls über das Formular.

### Zukünftig
Vielleicht noch schauen, dass beim Droppen der User jedes mal verifiziert wird, sodass man nicht doch irgendwie im Name anderer etwas schreiben kann