### PR TITLE
Clean code & refactoring - Startpage, Logik der Statusanzeige

### DIFF
--- a/src/main/java/stellarbytestudios/socialboard/controller/AnmeldungController.java
+++ b/src/main/java/stellarbytestudios/socialboard/controller/AnmeldungController.java
@@ -30,37 +30,33 @@ public class AnmeldungController {
     public String verify(Model m, RedirectAttributes redirectAttributes, String name, String password){
 
         System.out.println(name + " und " + password);
-        boolean verified;
 
         // Waren die Eingaben überhaupt korrekt?
         // Erstmal gucken, ob überhaupt genug Eingaben da sind
         if (name == null) {
-            verified = false;
-            m.addAttribute("verified", verified);
+            m.addAttribute("wrongData", true);
             return "startpage";
         }
         if (password == null) {
-            verified = false;
-            m.addAttribute("verified", verified);
+            m.addAttribute("wrongData", true);
             return "startpage";
         }
 
         // Wenn alle Eingaben vorhanden sind, wird geschaut, ob dieser Nutzer in der Datenbank so gespeichert ist
-        verified = loginService.validateUserLogin(name, password);
-
-        // Sind alle Verifizierungen durchgegangen wird der Userfeed angezeigt
-        if (verified){
-            // FlashAtributes sind kurzlebig und werden lokal statt über die URL übertragen
-            // Schließt Sicherheitslücke (einfacher Accoundwechsel über URL)
-            redirectAttributes.addFlashAttribute("username", name);
-
-            System.out.println("User wurde verifiziert");
-            return "redirect:" + USERCONTROLLER + USERFEED;
+        if (!loginService.validateUserLogin(name, password)){
+            // Verifizierung fehlgeschlagen
+            // Wird zurückgeleitet auf die Startseite
+            m.addAttribute("wrongData", true);
+            return "startpage";
         }
-        // Verifizierung fehlgeschlagen
-        // Wird zurückgeleitet auf die Startseite
-        m.addAttribute("verified", verified);
-        return "startpage";
+        // Sind alle Verifizierungen durchgegangen wird der Userfeed angezeigt
+        // FlashAtributes sind kurzlebig und werden lokal statt über die URL übertragen
+        // Schließt Sicherheitslücke (einfacher Accoundwechsel über URL)
+        redirectAttributes.addFlashAttribute("username", name);
+
+        System.out.println("User wurde verifiziert");
+        return "redirect:" + USERCONTROLLER + USERFEED;
+
 
     }
 }

--- a/src/main/java/stellarbytestudios/socialboard/controller/AnmeldungController.java
+++ b/src/main/java/stellarbytestudios/socialboard/controller/AnmeldungController.java
@@ -29,8 +29,6 @@ public class AnmeldungController {
     @GetMapping(VERIFYUSER)
     public String verify(Model m, RedirectAttributes redirectAttributes, String name, String password){
 
-        System.out.println(name + " und " + password);
-
         // Waren die Eingaben überhaupt korrekt?
         // Erstmal gucken, ob überhaupt genug Eingaben da sind
         if (name == null) {

--- a/src/main/java/stellarbytestudios/socialboard/controller/RegistrierungController.java
+++ b/src/main/java/stellarbytestudios/socialboard/controller/RegistrierungController.java
@@ -30,8 +30,6 @@ public class RegistrierungController {
                                   String passwordwiederholung){
 
 
-        System.out.println("Der Name: " + nameregi + "; das Passwort: " + passwordregi + "; die Wiederholung: " + passwordwiederholung);
-
         // Jetzt werden die Daten überprüft
         // Eigentlich sollten die Standartwerte immer false sein. Muss ich noch überprüfen
         // Sind alle eingaben da?

--- a/src/main/java/stellarbytestudios/socialboard/controller/RegistrierungController.java
+++ b/src/main/java/stellarbytestudios/socialboard/controller/RegistrierungController.java
@@ -40,8 +40,6 @@ public class RegistrierungController {
             m.addAttribute("noInputRegi", true);
             m.addAttribute("falsePassword", false);
             m.addAttribute("nameTaken", false);
-            // Anmeldung soll nicht verändert werden (Work in Progress)
-            m.addAttribute("verified", true);
 
             return "startpage";
         }
@@ -52,8 +50,6 @@ public class RegistrierungController {
             m.addAttribute("noInputRegi", false);
             m.addAttribute("falsePassword", false);
             m.addAttribute("nameTaken", true);
-            // Anmeldung soll nicht verändert werden (Work in Progress)
-            m.addAttribute("verified", true);
 
             return "startpage";
         }
@@ -63,8 +59,6 @@ public class RegistrierungController {
             m.addAttribute("noInputRegi", false);
             m.addAttribute("falsePassword", true);
             m.addAttribute("nameTaken", false);
-            // Anmeldung soll nicht verändert werden (Work in Progress)
-            m.addAttribute("verified", true);
 
             return "startpage";
         }

--- a/src/main/java/stellarbytestudios/socialboard/controller/StartPageController.java
+++ b/src/main/java/stellarbytestudios/socialboard/controller/StartPageController.java
@@ -13,9 +13,6 @@ public class StartPageController {
 
 @GetMapping(STARTPAGE)
     public String getStartPage(Model m){
-        // Damit beim ersten besuch nicht direkt die Warnung auftritt
-        m.addAttribute("verified", true);
-
         // Regeln des Registrierungsfensters
         m.addAttribute("firstVisit", true);
         return "startpage";

--- a/src/main/resources/templates/fragments/startpagefrag.html
+++ b/src/main/resources/templates/fragments/startpagefrag.html
@@ -37,7 +37,7 @@
         </p>
 
         <p><!-- Wenn die Anmeldung schiefgelaufen ist -->
-            <span class="alert-warning" th:unless="${verified}">Dein Nutzername oder Passwort sind Falsch</span>
+            <span class="alert-warning" th:if="${wrongData}">Dein Nutzername oder Passwort sind Falsch</span>
         </p>
     </form>
 </div>


### PR DESCRIPTION
Nur eine kleine Änderung. Zuvor musste die Anzeige, das beim Anmelden die Daten falsch sind immer die Verifikation in das Modell gegeben werden, obwohl das an der Stelle keinen wirklichen Sinn ergeben hat. Das ist jetzt abgeändert. Wegen der falsch-herumen Logik war das auch leider ein kleines Shot-Gun Refactoring

Zusätzlich wurden noch ein paar alte und überflüssige Print-Statements rausgelöscht